### PR TITLE
Autoupdate

### DIFF
--- a/examples/options-autoupdate.html
+++ b/examples/options-autoupdate.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>perfect-scrollbar example</title>
+    <link href="../dist/css/perfect-scrollbar.css" rel="stylesheet">
+    <script src="../dist/js/perfect-scrollbar.js"></script>
+    <style>
+      .contentHolder { position:relative; margin:0px auto; padding:0px; width: 80%; height: 400px; overflow: auto; }
+      .always-visible.contentHolder .content { background-image: url('./azusa.jpg'); width: 680px; height: 320px; }
+      .spacer { text-align:center }
+
+      .always-visible.ps-container > .ps-scrollbar-x-rail,
+      .always-visible.ps-container > .ps-scrollbar-y-rail {
+        opacity: 0.6;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="Default" class="contentHolder always-visible">
+      <div id="Content" class="content">
+      </div>
+    </div>
+    <p style='text-align: center'>
+      <button onclick='addContent()'>Add new content!</button>
+      <button onclick='removeContent()'>Remove content!</button>
+    </p>
+    <script>
+      var i = 1;
+      var $ = document.querySelector.bind(document);
+      window.onload = function () {
+        Ps.initialize($('#Default'), {
+          autoupdate: true
+        });
+      };
+
+      var addContent = function () {
+        var newDiv = document.createElement('div');
+        newDiv.id = 'node' + i++;
+        var newContent = document.createTextNode('Hi there!');
+        newDiv.appendChild(newContent);
+
+        $('#Default').insertBefore(newDiv, $('#Content'));
+      };
+
+      var removeContent = function () {
+        if (i <= 1) return;
+
+        var node = $('#node' + --i);
+        node.parentNode.removeChild(node);
+      };
+    </script>
+  </body>
+</html>
+

--- a/src/js/lib/helper.js
+++ b/src/js/lib/helper.js
@@ -23,6 +23,26 @@ var clone = exports.clone = function (obj) {
   }
 };
 
+exports.debounce = function (func, wait, immediate) {
+  var timeout;
+  return function () {
+    var context = this;
+    var args = arguments;
+    var later = function () {
+      timeout = null;
+      if (!immediate) {
+        func.apply(context, args);
+      }
+    };
+    var callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) {
+      func.apply(context, args);
+    }
+  };
+};
+
 exports.extend = function (original, source) {
   var result = clone(original);
   for (var key in source) {

--- a/src/js/plugin/autoupdate.js
+++ b/src/js/plugin/autoupdate.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var update = require('./update');
+var MutationObserver = window.MutationObserver;
+var instances = require('./instances');
+
+module.exports = function (element) {
+  if (MutationObserver === null || MutationObserver === undefined) {
+    // MutationObserver is not supported
+    return;
+  }
+
+  var i = instances.get(element);
+  var onMutationObserver = function () {
+    update(element);
+  };
+
+  i.observer = new MutationObserver(onMutationObserver);
+  onMutationObserver();
+
+  var config = { childList: true, subtree: true };
+  i.observer.observe(element, config);
+};

--- a/src/js/plugin/default-setting.js
+++ b/src/js/plugin/default-setting.js
@@ -12,5 +12,6 @@ module.exports = {
   useBothWheelAxes: false,
   wheelPropagation: false,
   wheelSpeed: 1,
-  theme: 'default'
+  theme: 'default',
+  autoupdate: true
 };

--- a/src/js/plugin/destroy.js
+++ b/src/js/plugin/destroy.js
@@ -11,6 +11,14 @@ module.exports = function (element) {
     return;
   }
 
+  if (i.observer) {
+    i.observer.disconnect();
+  }
+
+  if (i.resizer) {
+    i.resizer.remove();
+  }
+
   i.event.unbindAll();
   dom.remove(i.scrollbarX);
   dom.remove(i.scrollbarY);

--- a/src/js/plugin/destroy.js
+++ b/src/js/plugin/destroy.js
@@ -16,7 +16,7 @@ module.exports = function (element) {
   }
 
   if (i.resizer) {
-    i.resizer.remove();
+    i.resizer.parentNode.removeChild(i.resizer);
   }
 
   i.event.unbindAll();

--- a/src/js/plugin/destroy.js
+++ b/src/js/plugin/destroy.js
@@ -15,10 +15,6 @@ module.exports = function (element) {
     i.observer.disconnect();
   }
 
-  if (i.resizer) {
-    i.resizer.parentNode.removeChild(i.resizer);
-  }
-
   i.event.unbindAll();
   dom.remove(i.scrollbarX);
   dom.remove(i.scrollbarY);

--- a/src/js/plugin/initialize.js
+++ b/src/js/plugin/initialize.js
@@ -4,6 +4,8 @@ var _ = require('../lib/helper');
 var cls = require('../lib/class');
 var instances = require('./instances');
 var updateGeometry = require('./update-geometry');
+var autoupdate = require('./autoupdate');
+var resizer = require('./resizer');
 
 // Handlers
 var handlers = {
@@ -34,4 +36,9 @@ module.exports = function (element, userSettings) {
   nativeScrollHandler(element);
 
   updateGeometry(element);
+
+  if (i.settings.autoupdate) {
+    autoupdate(element);
+    resizer(element);
+  }
 };

--- a/src/js/plugin/resizer.js
+++ b/src/js/plugin/resizer.js
@@ -4,23 +4,11 @@ var update = require('./update');
 var instances = require('./instances');
 
 module.exports = function (element) {
-  var CSS = 'position:absolute;left:0;top:-100%;width:100%;height:100%;margin:1px 0 0;border:none;opacity:0;visibility:hidden;pointer-events:none;';
-
   var i = instances.get(element);
 
   var onMutationObserver = function () {
     update(element);
   };
 
-  var resizer = function (element, handler) {
-    var frame = document.createElement('iframe');
-    frame.style.cssText = CSS;
-    element.appendChild(frame);
-    frame.onload = function () {
-      i.event.bind(frame.contentWindow, 'resize', handler);
-    };
-    return frame;
-  };
-
-  i.resizer = resizer(element, onMutationObserver);
+  i.event.bind(window, 'resize', onMutationObserver);
 };

--- a/src/js/plugin/resizer.js
+++ b/src/js/plugin/resizer.js
@@ -2,13 +2,14 @@
 
 var update = require('./update');
 var instances = require('./instances');
+var _ = require('../lib/helper');
 
 module.exports = function (element) {
   var i = instances.get(element);
 
-  var onMutationObserver = function () {
+  var onResize = function () {
     update(element);
   };
 
-  i.event.bind(window, 'resize', onMutationObserver);
+  i.event.bind(window, 'resize', _.debounce(onResize, 60));
 };

--- a/src/js/plugin/resizer.js
+++ b/src/js/plugin/resizer.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var update = require('./update');
+var instances = require('./instances');
+
+module.exports = function (element) {
+  var CSS = 'position:absolute;left:0;top:-100%;width:100%;height:100%;margin:1px 0 0;border:none;opacity:0;visibility:hidden;pointer-events:none;';
+
+  var i = instances.get(element);
+
+  var onMutationObserver = function () {
+    update(element);
+  };
+
+  var resizer = function (element, handler) {
+    var frame = document.createElement('iframe');
+    frame.style.cssText = CSS;
+    element.appendChild(frame);
+    i.event.bind(frame.contentWindow, 'resize', handler);
+    return frame;
+  };
+
+  i.resizer = resizer(element, onMutationObserver);
+};

--- a/src/js/plugin/resizer.js
+++ b/src/js/plugin/resizer.js
@@ -16,7 +16,9 @@ module.exports = function (element) {
     var frame = document.createElement('iframe');
     frame.style.cssText = CSS;
     element.appendChild(frame);
-    i.event.bind(frame.contentWindow, 'resize', handler);
+    frame.onload = function () {
+      i.event.bind(frame.contentWindow, 'resize', handler);
+    };
     return frame;
   };
 


### PR DESCRIPTION
This PR adds an autoupdate option for perfect scrollbar. It's a PITA to have to do PS.update outside the library, specially if you have several instances at the same time. The scenario we want to resolve is that having a container with perfect scrollbar, some DOM node can be appended into it, so instead of checking when this happens to update PS, we delegate it to PS itself, using MutationObserver api. Also, window resize could affect the container, thus we are triggering the update on the resize event. In the first moment, I used an iframe as an resize observer for the poor (ResizeObserver api is only functional in latest Chrome), but iframe it's an expensive object, so for now, we have to play with the old window resize.

![scroll](https://cloud.githubusercontent.com/assets/1366843/21884475/c595e2ca-d8b3-11e6-99f9-8c831216c066.gif)
